### PR TITLE
Example of Water Cloud model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,91 @@
-*.iml
-.idea/
+*.png
+*.tif
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
 *.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# IPython Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# dotenv
+.env
+
+# virtualenv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,14 +18,13 @@ install:
   # This next line is needed to deal with GDAL on 3.6
   - conda config --add channels conda-forge
   - conda info -a
-  - conda create -q -n test python=$TRAVIS_PYTHON_VERSION numpy pytest pytest-cov coverage sphinx nose
+  - conda create -q -n test python=$TRAVIS_PYTHON_VERSION numpy scipy pytest pytest-cov coverage sphinx nose
   - source activate test
   - pip install -U codecov
   - python setup.py install
-  
+
 script:
   - pytest
 
 after_success:
   - coveralls
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+language: python
+python:
+  - "2.7"
+  - "3.6"
+install:
+  - sudo apt-get update
+  - echo $TRAVIS_PYTHON_VERSION
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+      wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
+    else
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+    fi
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  # This next line is needed to deal with GDAL on 3.6
+  - conda config --add channels conda-forge
+  - conda info -a
+  - conda create -q -n test python=$TRAVIS_PYTHON_VERSION numpy pytest pytest-cov coverage sphinx nose
+  - source activate test
+  - pip install -U codecov
+  - python setup.py install
+  
+script:
+  - pytest
+
+after_success:
+  - coveralls
+

--- a/multiply_forward_operators/__init__.py
+++ b/multiply_forward_operators/__init__.py
@@ -1,2 +1,3 @@
 from .dummy_optical_forward_operator import DummyOpticalForwardOperator
 from .dummy_sar_forward_operator import DummySARForwardOperator
+from sar_forward_model import sar_observation_operator

--- a/multiply_forward_operators/__init__.py
+++ b/multiply_forward_operators/__init__.py
@@ -1,3 +1,3 @@
 from .dummy_optical_forward_operator import DummyOpticalForwardOperator
 from .dummy_sar_forward_operator import DummySARForwardOperator
-from sar_forward_model import sar_observation_operator
+from .sar_forward_model import sar_observation_operator

--- a/multiply_forward_operators/sar_forward_model.py
+++ b/multiply_forward_operators/sar_forward_model.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+"""A simple Water cloud SAR operator
+"""
+import numpy as np
+
+
+def sar_observation_operator(x, polarisation):
+    """We assume that the WCM is given by
+    $$
+    \begin{align}
+    \sigma_0^{pp} &= A_{1}\cdot VWC\left[ 1 - \exp(-2\cdot A_2\cdot VWC/\cos\theta )\right]\\
+                &+ \sigma_{soil}^{pp}\cdot \exp(-2\cdot A_2\cdot VWC/\cos\theta )\\
+    \end{align}
+    $$
+    where for each polarisation we have two parameters: A1, A2. The model is
+    in this case parameterised by two input magnitudes: the VWC and soil
+    backscatter (in reality, we would have soil moisture etc instead of soil
+    backscatter, but this is just an example ;D). A1 and A2 are defined per
+    polarisation.
+
+    `x` is a 2D array where each row contains
+    """
+    x = np.atleast_2d(x)
+    theta = np.deg2rad(38.)  # Whathever the incidence angle is
+    mu = 1./np.cos(theta)  # Define mu as simpler
+    # the model parameters. Some made up numbers ;-)
+    parameters = {"VV": [0.15, 0.01],
+                  "VH": [0.14, 0.01]}
+    # Select model parameters
+    try:
+        A1, A2 = parameters[polarisation]
+    except KeyError:
+        raise ValueError("Only VV and VH polarisations available!")
+    sigma_0 = A1*x[:, 0]*(1 - np.exp(-2*mu*A2*x[:, 0])) + \
+        x[:, 1]*np.exp(-2*mu*A2*x[:, 0])
+    grad = x*0
+    n_elems = x.shape[0]
+    for i in xrange(n_elems):
+        grad[i, 0] = A1*(1 - np.exp(-2*mu*A2*x[i, 0])) + \
+            2*A1*A2*mu*x[i, 0]*np.exp(-2*mu*A2*x[i, 0]) - \
+            2*A2*mu*x[i, 1]*np.exp(-2*mu*A2*x[i, 0])
+        grad[i, 1] = np.exp(-2*mu*A2*x[i, 0])
+    return sigma_0, grad

--- a/multiply_forward_operators/sar_forward_model.py
+++ b/multiply_forward_operators/sar_forward_model.py
@@ -35,7 +35,7 @@ def sar_observation_operator(x, polarisation):
         x[:, 1]*np.exp(-2*mu*A2*x[:, 0])
     grad = x*0
     n_elems = x.shape[0]
-    for i in xrange(n_elems):
+    for i in range(n_elems):
         grad[i, 0] = A1*(1 - np.exp(-2*mu*A2*x[i, 0])) + \
             2*A1*A2*mu*x[i, 0]*np.exp(-2*mu*A2*x[i, 0]) - \
             2*A2*mu*x[i, 1]*np.exp(-2*mu*A2*x[i, 0])

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,10 @@ requirements:
   build:
     - python
     - setuptools
+    - numpy
+    - scipy
 
   run:
     - python
+    - numpy
+    - scipy

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,91 @@
+*.png
+*.tif
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# IPython Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# dotenv
+.env
+
+# virtualenv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject

--- a/tests/test_sar.py
+++ b/tests/test_sar.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+import os
+import sys
+
+import pytest
+from distutils import dir_util
+
+import numpy as np
+
+from scipy.optimize import approx_fprime
+
+myPath = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, myPath + '/../')
+print (sys.path)
+
+from multiply_forward_operators import sar_observation_operator
+
+
+def test_water_cloud_bs_vv():
+    x = np.atleast_2d(np.array([0.5, 2.]))
+    polarisation = "VV"
+    sigma, dsigma = sar_observation_operator(x, polarisation)
+    assert(np.allclose(sigma, 1.975, atol=1.e-3))
+
+
+def test_water_cloud_bs_vh():
+    x = np.atleast_2d(np.array([0.5, 1.1]))
+    polarisation = "VH"
+    sigma, dsigma = sar_observation_operator(x, polarisation)
+    assert(np.allclose(sigma, 1.087, atol=1.e-3))
+
+
+def test_water_cloud_bs_hh():
+    x = np.array([0.5, 1.1])
+    polarisation = "HH"
+    with pytest.raises(ValueError):
+        sigma, dsigma = sar_observation_operator(x, polarisation)
+
+
+def test_water_cloud_gradient_vv():
+    x = np.atleast_2d(np.array([0.5, 2.]))
+    polarisation = "VV"
+    sigma, dsigma = sar_observation_operator(x, polarisation)
+
+    def backscatter_gradient(t):
+        return sar_observation_operator(t, polarisation)[0]
+
+    finite_difference_gradient_approx = approx_fprime(x.squeeze(),
+                                                      backscatter_gradient,
+                                                      1e-6)
+    assert(np.allclose(dsigma.squeeze(),
+                       finite_difference_gradient_approx, atol=1e-2))
+
+
+def test_water_cloud_gradient_vh():
+    x = np.atleast_2d(np.array([0.5, 2.]))
+    polarisation = "VH"
+    sigma, dsigma = sar_observation_operator(x, polarisation)
+
+    def backscatter_gradient(t):
+        return sar_observation_operator(t, polarisation)[0]
+
+    finite_difference_gradient_approx = approx_fprime(x.squeeze(),
+                                                      backscatter_gradient,
+                                                      1e-6)
+    assert(np.allclose(dsigma.squeeze(),
+                       finite_difference_gradient_approx, atol=1e-2))
+
+
+def test_water_cloud_bs_vv_array():
+    x = np.array([[0.5, 2.], [0.5, 2.], [0.5, 2.]])
+    polarisation = "VV"
+    sigma, dsigma = sar_observation_operator(x, polarisation)
+    assert(np.allclose(sigma, np.array([1.975, 1.975, 1.975]), atol=1.e-3))
+
+
+def test_water_cloud_bs_vh_array():
+    x = np.array([[0.5, 1.1], [0.5, 1.1], [0.5, 1.1]])
+    polarisation = "VH"
+    sigma, dsigma = sar_observation_operator(x, polarisation)
+    print x
+    print sigma
+    assert(np.allclose(sigma, np.array([1.087, 1.087, 1.087]), atol=1.e-3))

--- a/tests/test_sar.py
+++ b/tests/test_sar.py
@@ -2,16 +2,14 @@
 import os
 import sys
 
-import pytest
-from distutils import dir_util
-
 import numpy as np
 
+import pytest
 from scipy.optimize import approx_fprime
+
 
 myPath = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, myPath + '/../')
-print (sys.path)
 
 from multiply_forward_operators import sar_observation_operator
 

--- a/tests/test_sar.py
+++ b/tests/test_sar.py
@@ -76,6 +76,4 @@ def test_water_cloud_bs_vh_array():
     x = np.array([[0.5, 1.1], [0.5, 1.1], [0.5, 1.1]])
     polarisation = "VH"
     sigma, dsigma = sar_observation_operator(x, polarisation)
-    print x
-    print sigma
     assert(np.allclose(sigma, np.array([1.087, 1.087, 1.087]), atol=1.e-3))


### PR DESCRIPTION
As requested by @McWhity ...
I have added an example of a very simple SAR observation operator. The aim is to demonstrate the operator, not to use it as it is! 

@TonioF  for some reason, I can't get the Python3 imports to work. This is what the tests are complaining about...

``` 
Hint: make sure your test modules/packages have valid Python names.
Traceback:
tests/test_sar.py:14: in <module>
    from multiply_forward_operators import sar_observation_operator
multiply_forward_operators/__init__.py:3: in <module>
    from sar_forward_model import sar_observation_operator
E   ModuleNotFoundError: No module named 'sar_forward_model'
```

Works fine on 2.7, but there has to be something wrong with how I import the package in `__init__.py`